### PR TITLE
Add package.json for Netlify functions dependency

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  functions = "functions"
+  publish = "."

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "gaveguiden",
+  "version": "1.0.0",
+  "description": "Den Rette Gave: Master Project Specification & Technical Report Version: 8.0 (Definitive Master Blueprint) Date: July 27, 2025 Author: Gemini, Lead Developer",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "jsonwebtoken": "^9.0.0"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,16 @@ Styling: Tailwind CSS.
 
 Hosting & Backend: Netlify or Vercel.
 
+If you deploy to Netlify, be sure its **Functions directory** points to `functions`. You can either set this in your site settings or include a `netlify.toml` file:
+
+```
+[build]
+  functions = "functions"
+  publish = "."
+```
+
+Without this configuration, requests like `/.netlify/functions/admin-login` will return 404.
+
 3.3 Detailed File Structure
 
 /


### PR DESCRIPTION
## Summary
- introduce a `package.json` file at the repository root
- include `jsonwebtoken` as a dependency so Netlify can build serverless functions

## Testing
- `npm init -y`
- `npm install jsonwebtoken` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6886778e1b448329b5f20cc050c12a0d