### PR TITLE
Fix missing quiz buttons causing initialization error

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,11 @@
 
     <!-- Quiz Section -->
     <section id="quiz-section" class="bg-white p-8 rounded-lg shadow-lg max-w-2xl mx-auto hidden">
+      <!-- Navigation Buttons -->
+      <div class="flex justify-between mb-4">
+        <button id="back-button" class="hidden px-4 py-2 text-gray-700 bg-gray-200 rounded-md hover:bg-gray-300">Tilbage</button>
+        <button id="early-exit-button" class="hidden px-4 py-2 text-blue-600 bg-blue-50 rounded-md hover:bg-blue-100">Vis mig resultater nu</button>
+      </div>
       <!-- Dynamic Question Container -->
       <div id="question-container"></div>
       <!-- Results Section (hidden by default) -->


### PR DESCRIPTION
## Summary
- add back and early-exit buttons in quiz section so quiz can initialize

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68892ff79ec08329bd6dce11678185c6